### PR TITLE
Indicate Default Complexity in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and currently used by SonarSource, CodeClimate and others.
 You can find more readings about cognitive complexity in
 [cognitive-complexity readme file](https://github.com/Melevir/cognitive_complexity/blob/master/README.md#what-is-cognitive-complexity).
 
-
+Default complexity is 7, can be configured via `--max-cognitive-complexity` option.
 
 ## Installation
 


### PR DESCRIPTION
Added default value of 7 to README as seen in [flake8-expression-complexity](https://github.com/best-doctor/flake8-expression-complexity#flake8-expression-complexity)

`DEFAULT_MAX_COGNITIVE_COMPLEXITY = 7`